### PR TITLE
Fix stylesheets, add bootstrap 3 support

### DIFF
--- a/css/datepicker.css
+++ b/css/datepicker.css
@@ -443,6 +443,13 @@
   cursor: default;
   background-color: transparent;
 }
+.datepicker .timepicker:hover {
+  background: none;
+}
+.datepicker .timepicker .time {
+  width: auto;
+  margin: 2px;
+}
 .input-append.date .add-on i,
 .input-prepend.date .add-on i {
   cursor: pointer;
@@ -511,12 +518,4 @@
 .datepicker.dropdown-menu td,
 .datepicker.datepicker-inline td {
   padding: 4px 5px;
-}
-.datepicker .timepicker .time {
-	width: auto;
-	margin: 2px;
-}
-
-.datepicker .timepicker:hover {
-	background: none;
 }

--- a/css/datepicker3.css
+++ b/css/datepicker3.css
@@ -729,6 +729,19 @@ fieldset[disabled] .datepicker table tr td span.active.disabled:hover.active {
   cursor: default;
   background-color: transparent;
 }
+.datepicker .timepicker:hover {
+  background: none;
+}
+.datepicker .timepicker .time {
+  width: auto;
+  margin: 2px;
+}
+.datepicker .timepicker .btn-small {
+  border-radius: 3px;
+  font-size: 12px;
+  line-height: 1.5;
+  padding: 1px 8px;
+}
 .input-group.date .input-group-addon i {
   cursor: pointer;
   width: 16px;

--- a/less/datepicker.less
+++ b/less/datepicker.less
@@ -217,6 +217,17 @@
 		cursor: default;
 		background-color: transparent;
 	}
+
+	// Timepicker styles
+	.timepicker {
+		&:hover {
+			background: none;
+		}
+		.time {
+			width: auto;
+			margin: 2px;
+		}
+	}
 }
 .input-append,
 .input-prepend {

--- a/less/datepicker3.less
+++ b/less/datepicker3.less
@@ -214,6 +214,23 @@
 		cursor: default;
 		background-color: transparent;
 	}
+
+	// Timepicker styles
+	.timepicker {
+		&:hover {
+			background: none;
+		}
+		.time {
+			width: auto;
+			margin: 2px;
+		}
+		.btn-small {
+			border-radius: 3px;
+			font-size: 12px;
+			line-height: 1.5;
+			padding: 1px 8px;
+		}
+	}
 }
 .input-group {
 	&.date {


### PR DESCRIPTION
Hello!

We need place all styles in the `.less` files, not in the `.css` directly, because `.css` generates with `lessc` command (see comments in the `build/*` files).

Also, I added styles for bootstrap 3 (which have no `btn-small` class on default).
